### PR TITLE
Use asciicast by default. Fixes #4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ logs/*
 *.tar
 honeyssh
 honeycfg
+.*

--- a/core/honeypot.go
+++ b/core/honeypot.go
@@ -194,7 +194,7 @@ func (h *Honeypot) HandleConnection(s ssh.Session) error {
 	defer logFd.Close()
 
 	// Start logging the terminal interactions
-	vio := ttylog.NewRecorder(vos.NewVIOAdapter(s, s, s), ttylog.NewUMLLogSink(logFd))
+	vio := ttylog.NewRecorder(vos.NewVIOAdapter(s, s, s), ttylog.NewAsciicastLogSink(logFd))
 
 	procName := h.configuration.OS.DefaultShell
 	procArgs := []string{procName}


### PR DESCRIPTION
Use asciicast by default for logging sessions.