### PR TITLE
Added ls(pci|usb|cpu)

### DIFF
--- a/commands/lscpu.go
+++ b/commands/lscpu.go
@@ -1,0 +1,68 @@
+package commands
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/josephlewis42/honeyssh/core/vos"
+)
+
+var (
+	// Match procfs.go
+	lscpuText = strings.TrimSpace(`
+Architecture:            x86_64
+  CPU op-mode(s):        32-bit, 64-bit
+  Address sizes:         40 bits physical, 48 bits virtual
+  Byte Order:            Little Endian
+CPU(s):                  1
+  On-line CPU(s) list:   0
+Vendor ID:               GenuineIntel
+  BIOS Vendor ID:        unknown
+  Model name:            unknown
+    BIOS CPU family:     1
+    CPU family:          6
+    Model:               63
+    Thread(s) per core:  1
+    Core(s) per socket:  1
+    Socket(s):           1
+    Stepping:            2
+    BogoMIPS:            1234.59
+    Flags:               fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx
+                         fxsr sse sse2 ss ht tm pbe syscall nx pdpe1gb rdtscp lm pni pclmulqdq dtes64 monitor ds_cpl
+                         vmx smx est tm2 ssse3 cx16 xtpr pdcm pcid dca sse4_1 sse4_2 x2apic popcnt tsc_deadline_timer
+                         aes xsave avx xsaveopt
+Virtualization features: 
+  Virtualization:        VT-x
+  Hypervisor vendor:     KVM
+  Virtualization type:   full
+Caches (sum of all):     
+  L1d:                   32 KiB (1 instance)
+  L1i:                   32 KiB (1 instance)
+  L2:                    4 MiB (1 instance)
+NUMA:                    
+  NUMA node(s):          1
+  NUMA node0 CPU(s):     0
+`)
+)
+
+// Lscpu implements the lscpu command.
+func Lscpu(virtOS vos.VOS) int {
+	cmd := &SimpleCommand{
+		Use:   "lscpu [OPTION...]",
+		Short: "Display information about the CPU architecture.",
+
+		// Never bail, even if args are bad.
+		NeverBail: true,
+	}
+
+	return cmd.Run(virtOS, func() int {
+		fmt.Fprintln(virtOS.Stdout(), lscpuText)
+		return 0
+	})
+}
+
+var _ vos.ProcessFunc = Lscpu
+
+func init() {
+	addBinCmd("lscpu", Lscpu)
+}

--- a/commands/lspci.go
+++ b/commands/lspci.go
@@ -1,0 +1,47 @@
+package commands
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/josephlewis42/honeyssh/core/vos"
+)
+
+var (
+	lspciText = strings.TrimSpace(`
+00:00.0 Host bridge: Intel Corporation 440FX - 82441FX PMC [Natoma] (rev 02)
+00:01.0 ISA bridge: Intel Corporation 82371SB PIIX3 ISA [Natoma/Triton II]
+00:01.1 IDE interface: Intel Corporation 82371SB PIIX3 IDE [Natoma/Triton II]
+00:01.2 USB controller: Intel Corporation 82371SB PIIX3 USB [Natoma/Triton II] (rev 01)
+00:01.3 Bridge: Intel Corporation 82371AB/EB/MB PIIX4 ACPI (rev 03)
+00:02.0 VGA compatible controller: Red Hat, Inc. Virtio 1.0 GPU (rev 01)
+00:03.0 Ethernet controller: Red Hat, Inc. Virtio network device
+00:04.0 Ethernet controller: Red Hat, Inc. Virtio network device
+00:05.0 SCSI storage controller: Red Hat, Inc. Virtio SCSI
+00:06.0 SCSI storage controller: Red Hat, Inc. Virtio block device
+00:07.0 SCSI storage controller: Red Hat, Inc. Virtio block device
+00:08.0 Unclassified device [00ff]: Red Hat, Inc. Virtio memory balloon
+  `)
+)
+
+// Lspci implements the lspci command.
+func Lspci(virtOS vos.VOS) int {
+	cmd := &SimpleCommand{
+		Use:   "lspci [OPTION...]",
+		Short: "List PCI devices.",
+
+		// Never bail, even if args are bad.
+		NeverBail: true,
+	}
+
+	return cmd.Run(virtOS, func() int {
+		fmt.Fprintln(virtOS.Stdout(), lspciText)
+		return 0
+	})
+}
+
+var _ vos.ProcessFunc = Lspci
+
+func init() {
+	addBinCmd("lspci", Lspci)
+}

--- a/commands/lsusb.go
+++ b/commands/lsusb.go
@@ -1,0 +1,36 @@
+package commands
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/josephlewis42/honeyssh/core/vos"
+)
+
+var (
+	lsusbText = strings.TrimSpace(`
+Bus 001 Device 001: ID 1d6b:0001 Linux Foundation 1.1 root hub
+	`)
+)
+
+// Lsusb implements the lsusb command.
+func Lsusb(virtOS vos.VOS) int {
+	cmd := &SimpleCommand{
+		Use:   "lspci [OPTION...]",
+		Short: "List USB devices.",
+
+		// Never bail, even if args are bad.
+		NeverBail: true,
+	}
+
+	return cmd.Run(virtOS, func() int {
+		fmt.Fprintln(virtOS.Stdout(), lsusbText)
+		return 0
+	})
+}
+
+var _ vos.ProcessFunc = Lsusb
+
+func init() {
+	addBinCmd("lsusb", Lsusb)
+}

--- a/core/vos/procfs.go
+++ b/core/vos/procfs.go
@@ -5,8 +5,8 @@ import (
 	"io/fs"
 	"time"
 
-	"github.com/spf13/afero"
 	"github.com/josephlewis42/honeyssh/third_party/memmapfs/mem"
+	"github.com/spf13/afero"
 )
 
 type procFile struct {


### PR DESCRIPTION
Fixes #23. Adds `lscpu`, `lspci`, and `lsusb` based on the contents of the existing `/proc/cpuinfo` and a DigitalOcean droplet.