### PR TITLE
Added pkill and killall

### DIFF
--- a/commands/killall.go
+++ b/commands/killall.go
@@ -1,0 +1,26 @@
+package commands
+
+import (
+	"github.com/josephlewis42/honeyssh/core/vos"
+)
+
+// Killall implements a no-op killall command.
+func Killall(virtOS vos.VOS) int {
+	cmd := &SimpleCommand{
+		Use:   "killall [OPTION]... [--] NAME...",
+		Short: "Kill a process by name.",
+		// Never bail, even if args are bad.
+		NeverBail: true,
+	}
+
+	return cmd.Run(virtOS, func() int {
+		// No-op.
+		return 0
+	})
+}
+
+var _ vos.ProcessFunc = Killall
+
+func init() {
+	addBinCmd("killall", Killall)
+}

--- a/commands/pkill.go
+++ b/commands/pkill.go
@@ -1,0 +1,26 @@
+package commands
+
+import (
+	"github.com/josephlewis42/honeyssh/core/vos"
+)
+
+// Pkill implements a no-op pkill command.
+func Pkill(virtOS vos.VOS) int {
+	cmd := &SimpleCommand{
+		Use:   "pkill [OPTION]... PATTERN",
+		Short: "Signal a process by pattern",
+		// Never bail, even if args are bad.
+		NeverBail: true,
+	}
+
+	return cmd.Run(virtOS, func() int {
+		// No-op.
+		return 0
+	})
+}
+
+var _ vos.ProcessFunc = Pkill
+
+func init() {
+	addBinCmd("pkill", Pkill)
+}


### PR DESCRIPTION
Fixes #21 

Adds no-op commands for `killall` and `pkill` like the existing `kill`.  These are some of the highest ranking missing commands with nearly 100 invocations each over the last couple of days.